### PR TITLE
Update readme to reference @ibm npm org

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Kubecost provides real-time cost visibility and insights by uncovering patterns 
 Using [npm](https://npmjs.org):
 
 ```bash
-$ npm install @kubecost/kubecost-eks-blueprints-addon
+$ npm install @ibm/kubecost-eks-blueprints-addon
 ```
 
 ## Usage


### PR DESCRIPTION
Update README.md's npm install command to reference @ibm/kubecost-eks-blueprints-addon. This is the same package as the one at the @kubecost organization, but the @kubecost org is deprecated.